### PR TITLE
Simplify taking min() and max() on static arrays with std::cmp.

### DIFF
--- a/goombay-rs/src/alignment/edit/needleman_wunsch.rs
+++ b/goombay-rs/src/alignment/edit/needleman_wunsch.rs
@@ -1,6 +1,7 @@
 use crate::align::global_base::{GlobalAlgorithm, GlobalAlignmentModel, Metric};
 use crate::align::scoring::GeneralScoring;
 use crate::align::{AlignmentData, GlobalAlignmentMatrix, PointerValues, Scoring};
+use std::cmp::max;
 
 pub struct NeedlemanWunsch<S: Scoring + Clone> {
     pub scores: S,
@@ -62,7 +63,7 @@ impl GlobalAlignmentMatrix<GeneralScoring> for NeedlemanWunsch<GeneralScoring> {
                 let ugap = score_matrix[i - 1][j] - self.scores.gap as i32;
                 let lgap = score_matrix[i][j - 1] - self.scores.gap as i32;
 
-                let tmax = [identity, ugap, lgap].iter().max().copied().unwrap();
+                let tmax = max(max(identity, ugap), lgap);
                 score_matrix[i][j] = tmax;
 
                 if tmax == identity {

--- a/goombay-rs/src/alignment/edit/wagner_fischer.rs
+++ b/goombay-rs/src/alignment/edit/wagner_fischer.rs
@@ -1,6 +1,7 @@
 use crate::align::global_base::{GlobalAlgorithm, GlobalAlignmentModel, Metric};
 use crate::align::scoring::LevenshteinScoring;
 use crate::align::{AlignmentData, GlobalAlignmentMatrix, PointerValues, Scoring};
+use std::cmp::min;
 
 pub struct WagnerFischer<S: Scoring + Clone> {
     pub scores: S,
@@ -59,7 +60,7 @@ impl GlobalAlignmentMatrix<LevenshteinScoring> for WagnerFischer<LevenshteinScor
                 let ugap = score_matrix[i - 1][j] + self.scores.gap as i32;
                 let lgap = score_matrix[i][j - 1] + self.scores.gap as i32;
 
-                let tmax = [identity, ugap, lgap].iter().min().copied().unwrap();
+                let tmax = min(min(identity, ugap), lgap);
                 score_matrix[i][j] = tmax;
 
                 if tmax == identity {

--- a/goombay-rs/src/alignment/global_base.rs
+++ b/goombay-rs/src/alignment/global_base.rs
@@ -1,5 +1,6 @@
 use crate::align::{AlignmentData, PointerValues};
 use spindalis::utils::Arr2D;
+use std::cmp::{max, min};
 
 #[derive(Clone)]
 pub enum GlobalAlgorithm {
@@ -76,11 +77,7 @@ impl GlobalAlignmentModel {
                 let j = self.data.subject.len();
                 score_matrix[i][j]
             }
-            Metric::Distance => [self.data.query.len(), self.data.subject.len()]
-                .iter()
-                .max()
-                .copied()
-                .unwrap()
+            Metric::Distance => max(self.data.query.len(), self.data.subject.len())
                 .saturating_sub(self.distance() as usize) as i32,
             // converting self.distance to usize is fine because
             // Lowrance Wagner and Wagner Fischer only return
@@ -95,20 +92,12 @@ impl GlobalAlignmentModel {
         match self.metric {
             Metric::Similarity => {
                 if self.data.query.is_empty() || self.data.subject.is_empty() {
-                    let max_len = [self.data.query.len(), self.data.subject.len()]
-                        .iter()
-                        .max()
-                        .copied()
-                        .unwrap_or(0_usize);
+                    let max_len = max(self.data.query.len(), self.data.subject.len());
                     return (max_len * self.mismatch) as i32;
                 }
                 let similarity = self.similarity();
-                let max_possible = [self.data.query.len(), self.data.subject.len()]
-                    .iter()
-                    .max()
-                    .copied()
-                    .unwrap()
-                    * self.identity;
+                let max_possible =
+                    max(self.data.query.len(), self.data.subject.len()) * self.identity;
                 max_possible as i32 - similarity.abs()
             }
             Metric::Distance => {
@@ -124,16 +113,8 @@ impl GlobalAlignmentModel {
         match self.metric {
             Metric::Similarity => {
                 let raw_sim = (self.similarity()) as f64;
-                let max_length = [self.data.query.len(), self.data.subject.len()]
-                    .iter()
-                    .max()
-                    .copied()
-                    .unwrap();
-                let min_length = [self.data.query.len(), self.data.subject.len()]
-                    .iter()
-                    .min()
-                    .copied()
-                    .unwrap();
+                let max_length = max(self.data.query.len(), self.data.subject.len());
+                let min_length = min(self.data.query.len(), self.data.subject.len());
                 let max_possible = (max_length * self.identity) as f64;
                 let min_possible =
                     -((min_length * self.mismatch + (max_length - min_length) * self.gap) as f64);
@@ -152,11 +133,7 @@ impl GlobalAlignmentModel {
         match self.metric {
             Metric::Similarity => 1_f64 - self.normalized_similarity(),
             Metric::Distance => {
-                let max_poss_dist = [self.data.query.len(), self.data.subject.len()]
-                    .iter()
-                    .max()
-                    .copied()
-                    .unwrap();
+                let max_poss_dist = max(self.data.query.len(), self.data.subject.len());
                 self.distance() as f64 / max_poss_dist as f64
             }
         }


### PR DESCRIPTION
If the number of elements we're comparing are fixed, using std::cmp::{min, max} is simpler, so we adjust all the places that were using Iterator-based approaches to use the 2-argument function instead.