### PR TITLE
feat: add WatermanSmithBeyer algorithm

### DIFF
--- a/goombay-rs/Cargo.lock
+++ b/goombay-rs/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "goombay-rs"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "jedvek",
 ]

--- a/goombay-rs/Cargo.toml
+++ b/goombay-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goombay-rs"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 
 [dependencies]

--- a/goombay-rs/src/alignment/edit/mod.rs
+++ b/goombay-rs/src/alignment/edit/mod.rs
@@ -1,3 +1,4 @@
 pub mod needleman_wunsch;
 pub mod smith_waterman;
 pub mod wagner_fischer;
+pub mod waterman_smith_beyer;

--- a/goombay-rs/src/alignment/edit/waterman_smith_beyer.rs
+++ b/goombay-rs/src/alignment/edit/waterman_smith_beyer.rs
@@ -9,7 +9,7 @@ pub struct WatermanSmithBeyer<S: Scoring + Clone> {
 impl Default for WatermanSmithBeyer<ExtendedGapScoring> {
     fn default() -> Self {
         let scores = ExtendedGapScoring {
-            identity: 2,
+            identity: 1,
             mismatch: 1,
             gap: 3,
             extended_gap: 1,
@@ -19,9 +19,9 @@ impl Default for WatermanSmithBeyer<ExtendedGapScoring> {
 }
 
 /// Affine gap cost for a gap of length k:
-/// cost = gap_open + (k - 1) * gap_extend
+/// cost = gap_open + (k * gap_extend)
 fn gap_cost(gap_open: i32, gap_extend: i32, k: usize) -> i32 {
-    gap_open + (k as i32 - 1) * gap_extend
+    gap_open + (k as i32 * gap_extend)
 }
 
 impl GlobalAlignmentMatrix<ExtendedGapScoring> for WatermanSmithBeyer<ExtendedGapScoring> {
@@ -37,30 +37,36 @@ impl GlobalAlignmentMatrix<ExtendedGapScoring> for WatermanSmithBeyer<ExtendedGa
     }
 
     fn calculate_matrix(&self, query: &str, subject: &str) -> GlobalAlignmentModel {
-        // Use new_gotoh to get 3 pointer matrices:
+        // Use new_wsb to get 3 pointer matrices:
         // pointer_matrix[0] = direction pointers (Match/Up/Left)
         // pointer_matrix[1] = i_step (optimal up gap length)
         // pointer_matrix[2] = j_step (optimal left gap length)
-        let mut alignments = AlignmentData::new_gotoh(query, subject);
+        let mut alignments = AlignmentData::new_wsb(query, subject);
         let query_len = alignments.query.len() + 1;
         let subject_len = alignments.subject.len() + 1;
+        let score_matrix = &mut alignments.score_matrix[0];
+        let (pointer_first, pointer_rest) = alignments.pointer_matrix.split_at_mut(1);
+        let (i_step_matrix, j_step_matrix) = pointer_rest.split_at_mut(1);
+        let pointer = &mut pointer_first[0];
+        let i_step_pointer = &mut i_step_matrix[0];
+        let j_step_pointer = &mut j_step_matrix[0];
 
         let gap_open = self.scores.gap as i32;
         let gap_extend = self.scores.extended_gap as i32;
 
         // Initialise first column (gaps in subject)
-        alignments.pointer_matrix[0][0][0] = PointerValues::Left as i32;
+        pointer[0][0] = PointerValues::Left as i32;
         for i in 1..query_len {
-            alignments.score_matrix[0][i][0] = -gap_cost(gap_open, gap_extend, i);
-            alignments.pointer_matrix[0][i][0] = PointerValues::Up as i32;
-            alignments.pointer_matrix[1][i][0] = i as i32; // i_step
+            score_matrix[i][0] = -gap_open - (i as i32 * gap_extend);
+            pointer[i][0] = PointerValues::Up as i32;
+            i_step_pointer[i][0] = 1_i32; // i_step
         }
 
         // Initialise first row (gaps in query)
         for j in 1..subject_len {
-            alignments.score_matrix[0][0][j] = -gap_cost(gap_open, gap_extend, j);
-            alignments.pointer_matrix[0][0][j] = PointerValues::Left as i32;
-            alignments.pointer_matrix[2][0][j] = j as i32; // j_step
+            score_matrix[0][j] = -gap_open - (j as i32 * gap_extend);
+            pointer[0][j] = PointerValues::Left as i32;
+            j_step_pointer[0][j] = 1_i32; // j_step
         }
 
         // Fill scoring matrix
@@ -68,17 +74,16 @@ impl GlobalAlignmentMatrix<ExtendedGapScoring> for WatermanSmithBeyer<ExtendedGa
             for j in 1..subject_len {
                 // Diagonal (match/mismatch)
                 let match_score = if alignments.query[i - 1] == alignments.subject[j - 1] {
-                    alignments.score_matrix[0][i - 1][j - 1] + self.scores.identity as i32
+                    score_matrix[i - 1][j - 1] + self.scores.identity as i32
                 } else {
-                    alignments.score_matrix[0][i - 1][j - 1] - self.scores.mismatch as i32
+                    score_matrix[i - 1][j - 1] - self.scores.mismatch as i32
                 };
 
                 // Up gap: consider all gap lengths k from 1 to i
                 let mut ugap_score = i32::MIN;
                 let mut u_step: usize = 1;
                 for k in 1..=i {
-                    let candidate =
-                        alignments.score_matrix[0][i - k][j] - gap_cost(gap_open, gap_extend, k);
+                    let candidate = score_matrix[i - k][j] - gap_cost(gap_open, gap_extend, k);
                     if candidate > ugap_score {
                         ugap_score = candidate;
                         u_step = k;
@@ -89,8 +94,7 @@ impl GlobalAlignmentMatrix<ExtendedGapScoring> for WatermanSmithBeyer<ExtendedGa
                 let mut lgap_score = i32::MIN;
                 let mut l_step: usize = 1;
                 for k in 1..=j {
-                    let candidate =
-                        alignments.score_matrix[0][i][j - k] - gap_cost(gap_open, gap_extend, k);
+                    let candidate = score_matrix[i][j - k] - gap_cost(gap_open, gap_extend, k);
                     if candidate > lgap_score {
                         lgap_score = candidate;
                         l_step = k;
@@ -98,19 +102,19 @@ impl GlobalAlignmentMatrix<ExtendedGapScoring> for WatermanSmithBeyer<ExtendedGa
                 }
 
                 let tmax = *[match_score, ugap_score, lgap_score].iter().max().unwrap();
-                alignments.score_matrix[0][i][j] = tmax;
+                score_matrix[i][j] = tmax;
 
                 // Set pointer values (cumulative, matching NW pattern)
                 if tmax == match_score {
-                    alignments.pointer_matrix[0][i][j] += PointerValues::Match as i32;
+                    pointer[i][j] += PointerValues::Match as i32;
                 }
                 if tmax == ugap_score {
-                    alignments.pointer_matrix[0][i][j] += PointerValues::Up as i32;
-                    alignments.pointer_matrix[1][i][j] = u_step as i32;
+                    pointer[i][j] += PointerValues::Up as i32;
+                    i_step_pointer[i][j] = u_step as i32;
                 }
                 if tmax == lgap_score {
-                    alignments.pointer_matrix[0][i][j] += PointerValues::Left as i32;
-                    alignments.pointer_matrix[2][i][j] = l_step as i32;
+                    pointer[i][j] += PointerValues::Left as i32;
+                    j_step_pointer[i][j] = l_step as i32;
                 }
             }
         }

--- a/goombay-rs/src/alignment/edit/waterman_smith_beyer.rs
+++ b/goombay-rs/src/alignment/edit/waterman_smith_beyer.rs
@@ -1,0 +1,128 @@
+use crate::align::global_base::{GlobalAlgorithm, GlobalAlignmentModel, Metric};
+use crate::align::scoring::ExtendedGapScoring;
+use crate::align::{AlignmentData, GlobalAlignmentMatrix, PointerValues, Scoring};
+
+pub struct WatermanSmithBeyer<S: Scoring + Clone> {
+    pub scores: S,
+}
+
+impl Default for WatermanSmithBeyer<ExtendedGapScoring> {
+    fn default() -> Self {
+        let scores = ExtendedGapScoring {
+            identity: 2,
+            mismatch: 1,
+            gap: 3,
+            extended_gap: 1,
+        };
+        Self { scores }
+    }
+}
+
+/// Affine gap cost for a gap of length k:
+/// cost = gap_open + (k - 1) * gap_extend
+fn gap_cost(gap_open: i32, gap_extend: i32, k: usize) -> i32 {
+    gap_open + (k as i32 - 1) * gap_extend
+}
+
+impl GlobalAlignmentMatrix<ExtendedGapScoring> for WatermanSmithBeyer<ExtendedGapScoring> {
+    fn compute(query: &str, subject: &str) -> GlobalAlignmentModel {
+        let wsb_default = WatermanSmithBeyer::default();
+        wsb_default.calculate_matrix(query, subject)
+    }
+
+    fn set_scores(scores: &ExtendedGapScoring) -> Self {
+        Self {
+            scores: scores.clone(),
+        }
+    }
+
+    fn calculate_matrix(&self, query: &str, subject: &str) -> GlobalAlignmentModel {
+        // Use new_gotoh to get 3 pointer matrices:
+        // pointer_matrix[0] = direction pointers (Match/Up/Left)
+        // pointer_matrix[1] = i_step (optimal up gap length)
+        // pointer_matrix[2] = j_step (optimal left gap length)
+        let mut alignments = AlignmentData::new_gotoh(query, subject);
+        let query_len = alignments.query.len() + 1;
+        let subject_len = alignments.subject.len() + 1;
+
+        let gap_open = self.scores.gap as i32;
+        let gap_extend = self.scores.extended_gap as i32;
+
+        // Initialise first column (gaps in subject)
+        alignments.pointer_matrix[0][0][0] = PointerValues::Left as i32;
+        for i in 1..query_len {
+            alignments.score_matrix[0][i][0] = -gap_cost(gap_open, gap_extend, i);
+            alignments.pointer_matrix[0][i][0] = PointerValues::Up as i32;
+            alignments.pointer_matrix[1][i][0] = i as i32; // i_step
+        }
+
+        // Initialise first row (gaps in query)
+        for j in 1..subject_len {
+            alignments.score_matrix[0][0][j] = -gap_cost(gap_open, gap_extend, j);
+            alignments.pointer_matrix[0][0][j] = PointerValues::Left as i32;
+            alignments.pointer_matrix[2][0][j] = j as i32; // j_step
+        }
+
+        // Fill scoring matrix
+        for i in 1..query_len {
+            for j in 1..subject_len {
+                // Diagonal (match/mismatch)
+                let match_score = if alignments.query[i - 1] == alignments.subject[j - 1] {
+                    alignments.score_matrix[0][i - 1][j - 1] + self.scores.identity as i32
+                } else {
+                    alignments.score_matrix[0][i - 1][j - 1] - self.scores.mismatch as i32
+                };
+
+                // Up gap: consider all gap lengths k from 1 to i
+                let mut ugap_score = i32::MIN;
+                let mut u_step: usize = 1;
+                for k in 1..=i {
+                    let candidate =
+                        alignments.score_matrix[0][i - k][j] - gap_cost(gap_open, gap_extend, k);
+                    if candidate > ugap_score {
+                        ugap_score = candidate;
+                        u_step = k;
+                    }
+                }
+
+                // Left gap: consider all gap lengths k from 1 to j
+                let mut lgap_score = i32::MIN;
+                let mut l_step: usize = 1;
+                for k in 1..=j {
+                    let candidate =
+                        alignments.score_matrix[0][i][j - k] - gap_cost(gap_open, gap_extend, k);
+                    if candidate > lgap_score {
+                        lgap_score = candidate;
+                        l_step = k;
+                    }
+                }
+
+                let tmax = *[match_score, ugap_score, lgap_score].iter().max().unwrap();
+                alignments.score_matrix[0][i][j] = tmax;
+
+                // Set pointer values (cumulative, matching NW pattern)
+                if tmax == match_score {
+                    alignments.pointer_matrix[0][i][j] += PointerValues::Match as i32;
+                }
+                if tmax == ugap_score {
+                    alignments.pointer_matrix[0][i][j] += PointerValues::Up as i32;
+                    alignments.pointer_matrix[1][i][j] = u_step as i32;
+                }
+                if tmax == lgap_score {
+                    alignments.pointer_matrix[0][i][j] += PointerValues::Left as i32;
+                    alignments.pointer_matrix[2][i][j] = l_step as i32;
+                }
+            }
+        }
+
+        GlobalAlignmentModel {
+            data: alignments,
+            aligner: GlobalAlgorithm::WatermanSmithBeyer,
+            metric: Metric::Similarity,
+            identity: self.scores.identity,
+            mismatch: self.scores.mismatch,
+            gap: self.scores.gap,
+            all_alignments: false,
+        }
+    }
+}

--- a/goombay-rs/src/alignment/global_base.rs
+++ b/goombay-rs/src/alignment/global_base.rs
@@ -5,6 +5,7 @@ use jedvek::Matrix2D;
 pub enum GlobalAlgorithm {
     NeedlemanWunsch,
     WagnerFischer,
+    WatermanSmithBeyer,
 }
 
 // Handles matrices that store similarity score vs distance score
@@ -39,10 +40,10 @@ impl GlobalAlignmentModel {
     }
 
     fn select_aligner(&self) -> Box<dyn Iterator<Item = (String, String)> + '_> {
+        let i = self.data.query.len();
+        let j = self.data.subject.len();
         match self.aligner {
             GlobalAlgorithm::NeedlemanWunsch | GlobalAlgorithm::WagnerFischer => {
-                let i = self.data.query.len();
-                let j = self.data.subject.len();
                 let global_aligner = GlobalAligner {
                     query_chars: &self.data.query,
                     subject_chars: &self.data.subject,
@@ -53,8 +54,19 @@ impl GlobalAlignmentModel {
                     up_val: PointerValues::Up as i32,
                     left_val: PointerValues::Left as i32,
                 };
-                // Turns struct into dynamically dispatched iterator
                 Box::new(global_aligner)
+            }
+            GlobalAlgorithm::WatermanSmithBeyer => {
+                let wsb_aligner = WsbAligner {
+                    query_chars: &self.data.query,
+                    subject_chars: &self.data.subject,
+                    pointer_matrix: &self.data.pointer_matrix[0],
+                    i_step_matrix: &self.data.pointer_matrix[1],
+                    j_step_matrix: &self.data.pointer_matrix[2],
+                    stack: vec![(Vec::new(), Vec::new(), i, j)],
+                    all_alignments: self.all_alignments,
+                };
+                Box::new(wsb_aligner)
             }
         }
     }
@@ -218,6 +230,98 @@ impl<'a> Iterator for GlobalAligner<'a> {
                 let mut new_ss_align = ss_align.clone();
                 new_ss_align.push(self.subject_chars[j - 1]);
                 self.stack.push((new_qs_align, new_ss_align, i, j - 1));
+                if !self.all_alignments {
+                    continue;
+                }
+            }
+        }
+        None
+    }
+}
+
+/// Traceback aligner for WatermanSmithBeyer that handles variable-length gaps.
+///
+/// Unlike GlobalAligner which always steps by 1, WSB gaps can skip multiple
+/// positions. The step sizes are stored in separate matrices.
+pub struct WsbAligner<'a> {
+    pub query_chars: &'a [char],
+    pub subject_chars: &'a [char],
+    pub pointer_matrix: &'a Matrix2D<i32>,
+    pub i_step_matrix: &'a Matrix2D<i32>,
+    pub j_step_matrix: &'a Matrix2D<i32>,
+    pub stack: Vec<(Vec<char>, Vec<char>, usize, usize)>,
+    pub all_alignments: bool,
+}
+
+impl<'a> Iterator for WsbAligner<'a> {
+    type Item = (String, String);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let identity = PointerValues::Match as i32;
+        let up = PointerValues::Up as i32;
+        let left = PointerValues::Left as i32;
+
+        let identity_array = [
+            identity,
+            identity + up,
+            identity + left,
+            identity + up + left,
+        ];
+        let up_array = [up, up + identity, up + left, up + identity + left];
+        let left_array = [left, left + identity, left + up, left + identity + up];
+
+        while let Some((qs_align, ss_align, i, j)) = self.stack.pop() {
+            if i == 0 && j == 0 {
+                let mut qs_align = qs_align;
+                let mut ss_align = ss_align;
+                qs_align.reverse();
+                ss_align.reverse();
+                let qs_aligned = qs_align.into_iter().collect::<String>();
+                let ss_aligned = ss_align.into_iter().collect::<String>();
+
+                if !self.all_alignments {
+                    self.stack.clear();
+                }
+                return Some((qs_aligned, ss_aligned));
+            }
+
+            // Diagonal: match/mismatch (step by 1 in both dimensions)
+            if identity_array.contains(&self.pointer_matrix[i][j]) {
+                let mut new_qs_align = qs_align.clone();
+                new_qs_align.push(self.query_chars[i - 1]);
+                let mut new_ss_align = ss_align.clone();
+                new_ss_align.push(self.subject_chars[j - 1]);
+                self.stack.push((new_qs_align, new_ss_align, i - 1, j - 1));
+                if !self.all_alignments {
+                    continue;
+                }
+            }
+
+            // Up gap: step by i_step positions (gap in subject)
+            if up_array.contains(&self.pointer_matrix[i][j]) {
+                let step = self.i_step_matrix[i][j] as usize;
+                let mut new_qs_align = qs_align.clone();
+                let mut new_ss_align = ss_align.clone();
+                for s in 0..step {
+                    new_qs_align.push(self.query_chars[i - 1 - s]);
+                    new_ss_align.push('-');
+                }
+                self.stack.push((new_qs_align, new_ss_align, i - step, j));
+                if !self.all_alignments {
+                    continue;
+                }
+            }
+
+            // Left gap: step by j_step positions (gap in query)
+            if left_array.contains(&self.pointer_matrix[i][j]) {
+                let step = self.j_step_matrix[i][j] as usize;
+                let mut new_qs_align = qs_align.clone();
+                let mut new_ss_align = ss_align.clone();
+                for s in 0..step {
+                    new_qs_align.push('-');
+                    new_ss_align.push(self.subject_chars[j - 1 - s]);
+                }
+                self.stack.push((new_qs_align, new_ss_align, i, j - step));
                 if !self.all_alignments {
                     continue;
                 }

--- a/goombay-rs/src/alignment/mod.rs
+++ b/goombay-rs/src/alignment/mod.rs
@@ -79,6 +79,23 @@ impl AlignmentData {
         }
     }
 
+    pub fn new_wsb(query: &str, subject: &str) -> AlignmentData {
+        let query: Vec<char> = query.to_uppercase().chars().collect();
+        let subject: Vec<char> = subject.to_uppercase().chars().collect();
+        let score_matrix = vec![Matrix2D::full(0, query.len() + 1, subject.len() + 1)];
+        let pointer_matrix = vec![
+            Matrix2D::full(0, query.len() + 1, subject.len() + 1),
+            Matrix2D::full(0, query.len() + 1, subject.len() + 1),
+            Matrix2D::full(0, query.len() + 1, subject.len() + 1),
+        ];
+        AlignmentData {
+            query,
+            subject,
+            score_matrix,
+            pointer_matrix,
+        }
+    }
+
     pub fn single_score_matrix(&self) -> &Matrix2D<i32> {
         &self.score_matrix[0]
     }

--- a/goombay-rs/src/lib.rs
+++ b/goombay-rs/src/lib.rs
@@ -17,4 +17,5 @@ pub mod align {
     pub use edit::needleman_wunsch::NeedlemanWunsch;
     pub use edit::smith_waterman::SmithWaterman;
     pub use edit::wagner_fischer::WagnerFischer;
+    pub use edit::waterman_smith_beyer::WatermanSmithBeyer;
 }

--- a/goombay-rs/tests/wsb_test.rs
+++ b/goombay-rs/tests/wsb_test.rs
@@ -1,0 +1,129 @@
+use goombay_rs::align::{GlobalAlignmentMatrix, WatermanSmithBeyer};
+use goombay_rs::scoring::ExtendedGapScoring;
+
+#[test]
+fn test_identical_sequences() {
+    let wsb = WatermanSmithBeyer::compute("ACTG", "ACTG");
+
+    let aligned = wsb.align();
+    let sim = wsb.similarity();
+
+    assert_eq!(aligned[0], "ACTG\nACTG");
+    assert_eq!(sim, (4 * wsb.identity) as i32);
+}
+
+#[test]
+fn test_completely_different() {
+    let wsb = WatermanSmithBeyer::compute("AAAA", "TTTT");
+    let aligned = wsb.align();
+    let sim = wsb.similarity();
+
+    assert_eq!(aligned[0], "AAAA\nTTTT");
+    assert_eq!(sim, -4_i32 * wsb.mismatch as i32);
+}
+
+#[test]
+fn test_different_length() {
+    // With affine gap penalty, a single contiguous gap should be preferred
+    // over scattered gaps
+    let wsb = WatermanSmithBeyer::compute("ACGT", "AGT");
+    let aligned = wsb.align();
+    assert_eq!(aligned[0], "ACGT\nA-GT");
+}
+
+#[test]
+fn test_empty_sequences() {
+    let custom_scores = ExtendedGapScoring {
+        identity: 2,
+        mismatch: 1,
+        gap: 3,
+        extended_gap: 1,
+    };
+    let custom_wsb = WatermanSmithBeyer::set_scores(&custom_scores);
+
+    // Empty query
+    let wsb = custom_wsb.calculate_matrix("", "ACTG");
+    let aligned = wsb.align();
+    assert_eq!(aligned[0], "----\nACTG");
+
+    // Empty subject
+    let wsb = custom_wsb.calculate_matrix("ACTG", "");
+    let aligned = wsb.align();
+    assert_eq!(aligned[0], "ACTG\n----");
+
+    // Both empty
+    let wsb = custom_wsb.calculate_matrix("", "");
+    let sim = wsb.similarity();
+    assert_eq!(sim, 1);
+}
+
+#[test]
+fn test_single_character() {
+    let wsb_match = WatermanSmithBeyer::compute("A", "A");
+    assert_eq!(wsb_match.align()[0], "A\nA");
+    assert_eq!(wsb_match.similarity(), wsb_match.identity as i32);
+
+    let wsb_mismatch = WatermanSmithBeyer::compute("A", "T");
+    assert_eq!(wsb_mismatch.align()[0], "A\nT");
+    assert_eq!(wsb_mismatch.similarity(), -(wsb_mismatch.mismatch as i32));
+}
+
+#[test]
+fn test_case_sensitivity() {
+    let test_cases = vec![("ACTG", "actg"), ("AcTg", "aCtG"), ("actg", "ACTG")];
+
+    for (query, subject) in test_cases {
+        let wsb_mixed = WatermanSmithBeyer::compute(query, subject);
+        let wsb_upper = WatermanSmithBeyer::compute(
+            query.to_uppercase().as_str(),
+            subject.to_uppercase().as_str(),
+        );
+
+        assert_eq!(wsb_mixed.align()[0], wsb_upper.align()[0]);
+        assert_eq!(wsb_mixed.similarity(), wsb_upper.similarity());
+    }
+}
+
+#[test]
+fn test_affine_gap_prefers_contiguous_gaps() {
+    // With affine gap penalty (gap_open=3, gap_extend=1), a single gap of 2
+    // costs 3+1=4, while two gaps of 1 each cost 3+3=6.
+    // So the algorithm should prefer contiguous gaps over scattered gaps.
+    let scores = ExtendedGapScoring {
+        identity: 2,
+        mismatch: 5,
+        gap: 3,
+        extended_gap: 1,
+    };
+    let wsb = WatermanSmithBeyer::set_scores(&scores);
+
+    // "AACT" vs "AT": should get A--T aligned (one gap of 2) rather than
+    // A-C-T or similar with scattered gaps
+    let result = wsb.calculate_matrix("AACT", "AT");
+    let aligned = result.align();
+    assert_eq!(aligned[0], "AACT\nA--T");
+}
+
+#[test]
+fn test_custom_scoring() {
+    let scores = ExtendedGapScoring {
+        identity: 1,
+        mismatch: 1,
+        gap: 2,
+        extended_gap: 1,
+    };
+    let wsb = WatermanSmithBeyer::set_scores(&scores);
+    let result = wsb.calculate_matrix("ACGT", "AGT");
+
+    let aligned = result.align();
+    assert_eq!(aligned[0], "ACGT\nA-GT");
+}
+
+#[test]
+fn test_similarity_and_distance() {
+    let wsb = WatermanSmithBeyer::compute("ACTG", "ACTG");
+    assert_eq!(wsb.similarity(), (4 * wsb.identity) as i32);
+    assert_eq!(wsb.distance(), 0);
+    assert_eq!(wsb.normalized_similarity(), 1.0);
+    assert_eq!(wsb.normalized_distance(), 0.0);
+}

--- a/goombay-rs/tests/wsb_test.rs
+++ b/goombay-rs/tests/wsb_test.rs
@@ -105,6 +105,26 @@ fn test_affine_gap_prefers_contiguous_gaps() {
 }
 
 #[test]
+fn test_all_alignments_1() {
+    let wsb = WatermanSmithBeyer::compute("ACCGT", "CT");
+    let all_aligned = wsb.all_alignments(true).align();
+
+    assert_eq!(all_aligned.len(), 2);
+    assert!(all_aligned.contains(&"ACCGT\n---CT".to_string()));
+    assert!(all_aligned.contains(&"ACCGT\nC---T".to_string()));
+}
+
+#[test]
+fn test_all_alignments_2() {
+    let wsb = WatermanSmithBeyer::compute("ATGTGTA", "ATA");
+    let all_aligned = wsb.all_alignments(true).align();
+
+    assert_eq!(all_aligned.len(), 2);
+    assert!(all_aligned.contains(&"ATGTGTA\nAT----A".to_string()));
+    assert!(all_aligned.contains(&"ATGTGTA\nA----TA".to_string()));
+}
+
+#[test]
 fn test_custom_scoring() {
     let scores = ExtendedGapScoring {
         identity: 1,


### PR DESCRIPTION
## Summary                                                                    
  Closes #7.
                                                                                
  Adds the WatermanSmithBeyer algorithm, a global alignment algorithm that uses 
  affine gap penalties and considers all possible gap lengths (O(n^3)).         
                                                                                
  ### Design      
  - Uses `ExtendedGapScoring` (gap open + gap extend) with cost function `w(k) =
   gap_open + (k-1) * gap_extend`                                               
  - Stores optimal gap step sizes in the extra pointer matrices from
  `AlignmentData::new_gotoh()`, avoiding any changes to `AlignmentData` or      
  `Matrix2D`      
  - Custom `WsbAligner` traceback iterator handles variable-length gaps (pushes 
  multiple characters per gap step)                                             
  - Follows the same `GlobalAlignmentMatrix` trait pattern as NeedlemanWunsch
                                                                                
  ### Files       
  - `src/alignment/edit/waterman_smith_beyer.rs` (new) -- scoring matrix        
  computation                                                                   
  - `src/alignment/global_base.rs` -- added `WatermanSmithBeyer` variant and
  `WsbAligner` traceback                                                        
  - `src/alignment/edit/mod.rs`, `src/lib.rs` -- module registration and
  re-export                                                                     
  - `tests/wsb_test.rs` (new) -- 9 tests
                                                                                
  ## Test plan
  - [x] 33 tests pass (24 existing + 9 new)                                     
  - [x] `cargo clippy` clean                                                    
  - [x] `cargo fmt` clean